### PR TITLE
decorate function definitions from within rcviz and fix open issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@ def count_partitions(n, m):
         document.getElementById("visualize-status").innerHTML = "Computing call graph...";
         const functionDef = document.getElementById('function-definition-textarea').value;
         const functionCall = document.getElementById('function-call-input').value;
-        const dotGraph = pyodide.runPython(`visualize("""@viz\n${functionDef}""", '${functionCall}')`);
+        const dotGraph = pyodide.runPython(`visualize('''${functionDef}''', '''${functionCall}''')`);
         document.getElementById("visualize-status").innerHTML = "Rendering call graph...";
         hpccWasm.graphvizSync().then(graphviz => {
               const div = document.getElementById("placeholder");

--- a/rcviz.py
+++ b/rcviz.py
@@ -187,9 +187,19 @@ class viz(object):
         return ret
 
 
+def decorate_funcs(func_source: str):
+    outlines = []
+    for line in func_source.split("\n"):
+        if line.startswith("def "):
+            outlines.append("@viz")
+        outlines.append(line)
+    return "\n".join(outlines)
+
+
 def visualize(function_definition, function_call):
   """Either returns generated SVG or generates an error."""
   callgraph.reset()
+  function_definition=decorate_funcs(function_definition)
   exec(function_definition, globals())
   eval(function_call)
   return callgraph.render()


### PR DESCRIPTION
Three fixes: 

1. I wanted to update [this stackoverflow answer](https://stackoverflow.com/questions/9170678/understanding-and-visualizing-recursion/23849982) to point to this tool, but it didn't work because of some global variables above the function definition. By moving the decoration insertion to the rcviz side, we can render the code from that question:

```python
st= []
def combi(prefix, s):
    if len(s)==0: 
        return 
    else:
        st.append(prefix+s[0])     
        combi(prefix+s[0],s[1:])
        combi(prefix,s[1:])
        return st

combi("",'abc')
```
This gives us for free the ability to have multiple functions in the source code, so something like this renders calls to both foo and bar functions:

```python
 
def foo(n):
  return bar(2*n)

def bar(n):
  if n==1:
    return n
  return bar(n-1)

foo(4)
```
While fixing that, I noticed we could fix the open issues trivially too:
2. allow triple quoted docstrings in function code. (of course this fix now disallows triple single quoted docstrings but PEP 257 and convention is to use triple double quotes, so it should be okay)
3. allow single quotes in function args 

Happy to separate out the PRs if there are any issues. e.g. I could also use a regex to search for the function defs instead of the startswith