### PR TITLE
Deep copy mutable args

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+__pycache__

--- a/rcviz.py
+++ b/rcviz.py
@@ -185,7 +185,11 @@ class viz(object):
 
         if this_frame_id not in g_callers.keys():
             g_callers[this_frame_id] = node_data(
-                copy.deepcopy(args), copy.deepcopy(kwargs), self.wrapped.__name__, None, []
+                copy.deepcopy(args),
+                copy.deepcopy(kwargs),
+                self.wrapped.__name__,
+                None,
+                [],
             )
 
         edgeinfo = None

--- a/rcviz.py
+++ b/rcviz.py
@@ -185,7 +185,7 @@ class viz(object):
 
         if this_frame_id not in g_callers.keys():
             g_callers[this_frame_id] = node_data(
-                args, kwargs, self.wrapped.__name__, None, []
+                copy.deepcopy(args), copy.deepcopy(kwargs), self.wrapped.__name__, None, []
             )
 
         edgeinfo = None

--- a/rcviz_test.py
+++ b/rcviz_test.py
@@ -5,7 +5,6 @@ from rcviz import visualize, TooManyFramesError, TooMuchTimeError
 class TestRCViz(unittest.TestCase):
 
   fib_def = """
-@viz
 def fib(n):
   if n == 0:
     return 0
@@ -15,8 +14,21 @@ def fib(n):
     return fib(n - 1) + fib(n - 2)"""
 
   def test_svg(self):
-    svg = visualize(self.fib_def, 'fib(2)')
-    self.assertIn('fib(1)', svg)
+    dotgraph = visualize(self.fib_def, 'fib(2)')
+    self.assertIn('fib(1)', dotgraph)
+
+  def test_mutable_args(self):
+    rev_def = """
+def rev(lst, start, end):
+  if start < end:
+    tmp = lst[end]
+    lst[end] = lst[start]
+    lst[start] = tmp
+    rev(lst, start+1, end-1)
+"""
+    dotgraph = visualize(rev_def, 'rev([1, 2, 3, 4, 5], 0, 4)')
+    self.assertIn('rev([5, 2, 3, 4, 1], 1, 3)', dotgraph)
+    self.assertIn('rev([5, 4, 3, 2, 1], 2, 2)', dotgraph)
 
   def test_error_too_many_nodes(self):
     with self.assertRaises(TooManyFramesError):
@@ -24,13 +36,14 @@ def fib(n):
 
   def test_error_too_much_time(self):
     while_def = """
-@viz
 def inf():
   while True:
     inf()
 """
     with self.assertRaises(TooMuchTimeError):
       visualize(while_def, 'inf()')
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/rcviz_test.py
+++ b/rcviz_test.py
@@ -2,9 +2,10 @@ import unittest
 
 from rcviz import visualize, TooManyFramesError, TooMuchTimeError
 
+
 class TestRCViz(unittest.TestCase):
 
-  fib_def = """
+    fib_def = """
 def fib(n):
   if n == 0:
     return 0
@@ -13,12 +14,12 @@ def fib(n):
   else:
     return fib(n - 1) + fib(n - 2)"""
 
-  def test_svg(self):
-    dotgraph = visualize(self.fib_def, 'fib(2)')
-    self.assertIn('fib(1)', dotgraph)
+    def test_svg(self):
+        dotgraph = visualize(self.fib_def, "fib(2)")
+        self.assertIn("fib(1)", dotgraph)
 
-  def test_mutable_args(self):
-    rev_def = """
+    def test_mutable_args(self):
+        rev_def = """
 def rev(lst, start, end):
   if start < end:
     tmp = lst[end]
@@ -26,24 +27,23 @@ def rev(lst, start, end):
     lst[start] = tmp
     rev(lst, start+1, end-1)
 """
-    dotgraph = visualize(rev_def, 'rev([1, 2, 3, 4, 5], 0, 4)')
-    self.assertIn('rev([5, 2, 3, 4, 1], 1, 3)', dotgraph)
-    self.assertIn('rev([5, 4, 3, 2, 1], 2, 2)', dotgraph)
+        dotgraph = visualize(rev_def, "rev([1, 2, 3, 4, 5], 0, 4)")
+        self.assertIn("rev([5, 2, 3, 4, 1], 1, 3)", dotgraph)
+        self.assertIn("rev([5, 4, 3, 2, 1], 2, 2)", dotgraph)
 
-  def test_error_too_many_nodes(self):
-    with self.assertRaises(TooManyFramesError):
-      visualize(self.fib_def, 'fib(14)')
+    def test_error_too_many_nodes(self):
+        with self.assertRaises(TooManyFramesError):
+            visualize(self.fib_def, "fib(14)")
 
-  def test_error_too_much_time(self):
-    while_def = """
+    def test_error_too_much_time(self):
+        while_def = """
 def inf():
   while True:
     inf()
 """
-    with self.assertRaises(TooMuchTimeError):
-      visualize(while_def, 'inf()')
+        with self.assertRaises(TooMuchTimeError):
+            visualize(while_def, "inf()")
 
 
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
To fix #9, we always make a deepcopy of args/kwargs in nodedata. We were already doing this for return values.