### PR TITLE
Support arguments with curly braces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .coverage
 venv/
+node_modules

--- a/python/rcviz.py
+++ b/python/rcviz.py
@@ -64,7 +64,7 @@ class callgraph(object):
 
         # Create nodes
         for frame_id, node in callgraph.get_callers().items():
-            label = f"{{ {node.fn_name}({node.argstr()}) }}"
+            label = f"{node.fn_name}({node.argstr()})"
             dotgraph.add_node(pydot.Node(frame_id, label=label, shape="Mrecord"))
 
         # Create edges
@@ -132,7 +132,7 @@ class node_data(object):
     def argstr(self):
         s_args = ", ".join([str(arg) for arg in self.args])
         s_kwargs = ", ".join([(str(k), str(v)) for (k, v) in self.kwargs.items()])
-        return f"{s_args}{s_kwargs}"
+        return f"{s_args}{s_kwargs}".replace("{", "\{").replace("}", "\}")
 
 
 class viz(object):

--- a/python/rcviz_test.py
+++ b/python/rcviz_test.py
@@ -102,8 +102,8 @@ def finditem(obj, key):
     dotgraph = pydot.graph_from_dot_data(dotgraph_str)[0]
 
     assert [n.get_label() for n in dotgraph.get_nodes()] == [
-        '"finditem(\\{\'B\': 1, \'A\': \\{\'C\': 2\\}\\}, C)"',
-        '"finditem(\\{\'C\': 2\\}, C)"',
+        "\"finditem(\\{'B': 1, 'A': \\{'C': 2\\}\\}, C)\"",
+        "\"finditem(\\{'C': 2\\}, C)\"",
         "Result",
         None,
     ]

--- a/python/rcviz_test.py
+++ b/python/rcviz_test.py
@@ -21,11 +21,11 @@ def test_visualize():
     assert len(dotgraph.get_nodes()) == 7
     assert len(dotgraph.get_edges()) == 9
     assert [n.get_label() for n in dotgraph.get_nodes()] == [
-        '"{ virfib(3) }"',
-        '"{ virfib(2) }"',
-        '"{ virfib(1) }"',
-        '"{ virfib(0) }"',
-        '"{ virfib(1) }"',
+        '"virfib(3)"',
+        '"virfib(2)"',
+        '"virfib(1)"',
+        '"virfib(0)"',
+        '"virfib(1)"',
         "Result",
         None,
     ]
@@ -76,9 +76,34 @@ def rev(lst, start, end):
     assert len(dotgraph.get_nodes()) == 4
     assert len(dotgraph.get_edges()) == 2
     assert [n.get_label() for n in dotgraph.get_nodes()] == [
-        '"{ rev([1, 2, 3, 4, 5], 0, 4) }"',
-        '"{ rev([5, 2, 3, 4, 1], 1, 3) }"',
-        '"{ rev([5, 4, 3, 2, 1], 2, 2) }"',
+        '"rev([1, 2, 3, 4, 5], 0, 4)"',
+        '"rev([5, 2, 3, 4, 1], 1, 3)"',
+        '"rev([5, 4, 3, 2, 1], 2, 2)"',
         None,
     ]
     assert [e.get_label() for e in dotgraph.get_edges()] == ['"(#1)"', '"(#2)"']
+
+
+def test_dict_args():
+    # Ensure that curly braces get escaped, since curly braces have meaning in dot graphs.
+
+    dict_def = """
+def finditem(obj, key):
+    if key in obj:
+      return obj[key]
+    for k, v in obj.items():
+        if isinstance(v, dict):
+            item = finditem(v, key)
+            if item is not None:
+                return item
+    """
+
+    dotgraph_str = rcviz.visualize(dict_def, "finditem({'B':1,'A': {'C': 2}},'C')")
+    dotgraph = pydot.graph_from_dot_data(dotgraph_str)[0]
+
+    assert [n.get_label() for n in dotgraph.get_nodes()] == [
+        '"finditem(\\{\'B\': 1, \'A\': \\{\'C\': 2\\}\\}, C)"',
+        '"finditem(\\{\'C\': 2\\}, C)"',
+        "Result",
+        None,
+    ]


### PR DESCRIPTION
Addresses #16 

The issue is that curly braces actually have meaning in the label of a dotgraph (they signify a list), so the curly braces in sets/dicts were getting misinterpreted. The solution I've used is to escape those curly braces.

I also removed the outer curly braces that we used to send down with labels, since we're not sending a list any more.

Test added to check for new behavior.

